### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install stable virtualenv # https://github.com/pre-commit/action/issues/135
-        run: pip install -U virtualenv==20.10.0
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v2.0.3
-
       - name: Install tox
-        run: pip install tox
+        run: |
+          python -m pip install --upgrade pip setuptools tox
 
       - name: Cache tox environments
         id: cache-tox
@@ -41,7 +36,7 @@ jobs:
             tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
 
       - name: Run tox
-        run: tox -e py,coverage-report,typing
+        run: tox -e lint,typing,py,coverage-report
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
           - 3.8
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache tox environments
         id: cache-tox
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .tox
           # requirements/*.txt and pyproject.toml have versioning info
@@ -48,7 +48,7 @@ jobs:
     needs: [test]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
- Update checkout, setup-python, and cache actions to v3

- Move pre-commit linting step to tox since pre-commit/actions is deprecated.