### PR TITLE
Handle redirects from x-amz-meta-dir-redirect

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: "ghcr.io/jsickcodes/ltd-proxy"
-    newTag: 0.2.0
+    newTag: 0.3.0
 
 resources:
   - configmap.yaml


### PR DESCRIPTION
LTD has a way of creating S3 objects that indicate they're the name of a directory, and that therefore the content can be found at `{original_key}/index.html`. This change looks for the header and if it has a true value, sends a redirect to the browser.